### PR TITLE
Fix crash when no cameras are connected

### DIFF
--- a/src/indi_pylibcamera/indi_pylibcamera.py
+++ b/src/indi_pylibcamera/indi_pylibcamera.py
@@ -636,8 +636,12 @@ class indi_pylibcamera(indidevice):
         logger.info(f'found cameras: {cameras}')
         # use Id as unique camera identifier
         self.Cameras = [f'{c["Model"]}, Num{c["Num"]}, Loc{c["Location"]}' for c in cameras]
-        CameraToConnect = min(self.config.getint("driver", "SelectCameraDevice", fallback=0), len(self.Cameras) - 1)
-        logger.info(f'camera to connect by default: {self.Cameras[CameraToConnect]}')
+        # We may have no cameras attached to the system
+        if self.Cameras:
+            CameraToConnect = min(self.config.getint("driver", "SelectCameraDevice", fallback=0), len(self.Cameras) - 1)
+            logger.info(f'camera to connect by default: {self.Cameras[CameraToConnect]}')
+        else:
+            logger.info(f'No cameras connected')
         # INDI vector names only available with connected camera
         self.CameraVectorNames = []
         # INDI general vectors


### PR DESCRIPTION
If no camera are attached, the line containing `self.Cameras[CameraToConnect]` is crashing the process. This will take care of that case